### PR TITLE
feat(deploy): run LibreChat behind centralized Traefik reverse proxy

### DIFF
--- a/DEPLOYMENT-TRAEFIK.md
+++ b/DEPLOYMENT-TRAEFIK.md
@@ -1,0 +1,95 @@
+# Deploying LibreChat behind Traefik
+
+This supersedes the nginx-sidecar approach in [`DEPLOYMENT.md`](./DEPLOYMENT.md). On the
+droplet, a single **Traefik** reverse proxy (its own project under `/opt/proxy`) owns ports
+80/443 and handles SSL for **every** project — LibreChat today, Strapi and others later —
+so there are no port conflicts and no per-project nginx config to maintain.
+
+## Architecture
+
+```
+Internet :80/:443
+      │
+      ▼
+  Traefik (/opt/proxy, project "proxy")     ← only public entrypoint; ACME / Let's Encrypt
+      │  (shared external docker network: "web")
+      ├── chat.omniventus.com  ──►  LibreChat-API:3080
+      └── (future projects … each via labels + the "web" network)
+```
+
+- **`docker-compose.traefik.yml`** (this repo, project `librechat`): the LibreChat stack —
+  `api`, `meilisearch`, `vectordb`, `rag_api`. No nginx `client`; `api` is `expose`d (not
+  published) and joined to the external `web` network with Traefik routing labels.
+- **`utils/docker/proxy/docker-compose.yml`**: the standalone Traefik project (deployed to
+  `/opt/proxy`).
+- MongoDB is **not** in the compose — production uses **MongoDB Atlas** via `MONGO_URI` in `.env`.
+
+## First-time setup
+
+```bash
+# 1. Shared network (once)
+docker network create web
+
+# 2. Traefik project
+sudo mkdir -p /opt/proxy/letsencrypt
+sudo cp utils/docker/proxy/docker-compose.yml /opt/proxy/docker-compose.yml
+sudo touch /opt/proxy/letsencrypt/acme.json && sudo chmod 600 /opt/proxy/letsencrypt/acme.json
+
+# 3. Issue a STAGING cert first (avoid burning the LE production rate limit):
+#    uncomment the `caserver` staging line in /opt/proxy/docker-compose.yml, then:
+cd /opt/proxy && docker compose up -d
+docker logs traefik 2>&1 | grep -iE 'acme|certificate|error'
+echo | openssl s_client -connect chat.omniventus.com:443 -servername chat.omniventus.com 2>/dev/null \
+  | openssl x509 -noout -issuer -dates           # issuer must contain "(STAGING)"
+
+# 4. Switch to the REAL cert: re-comment the staging line, wipe the store, restart:
+cd /opt/proxy && docker compose down
+: > letsencrypt/acme.json && chmod 600 letsencrypt/acme.json
+docker compose up -d
+
+# 5. Deploy LibreChat
+cd /path/to/LibreChat && ./utils/docker/deploy-traefik.sh
+```
+
+Verify: `curl -sI https://chat.omniventus.com | head -1` returns `HTTP/2 200` **without** `-k`,
+and the cert issuer is `Let's Encrypt` (no `(STAGING)`).
+
+## Migrating from the nginx stack (host nginx or the `client` sidecar)
+
+The old setup terminated TLS with nginx (a host `systemd` nginx, or the docker `client`
+service) proxying to `localhost:3080`. To cut over:
+
+```bash
+# Free 80/443 — stop whatever currently terminates TLS, and the certbot timer
+sudo systemctl stop nginx && sudo systemctl disable nginx           # if a HOST nginx owns 80/443
+sudo systemctl stop certbot.timer && sudo systemctl disable certbot.timer
+# (the docker `client` sidecar, if any, is removed automatically by --remove-orphans below)
+
+# Start Traefik (see "First-time setup"), then deploy LibreChat in Traefik mode:
+./utils/docker/deploy-traefik.sh
+```
+
+## Rollback
+
+The previous certs and stack are left intact as a safety net:
+
+```bash
+cd /opt/proxy && docker compose down                # release 80/443
+sudo systemctl enable --now nginx                   # restore the host nginx (if that was the setup)
+sudo systemctl enable --now certbot.timer
+docker compose -p librechat -f docker-compose.production.yml up -d   # legacy nginx-sidecar stack
+```
+
+## Operational notes / gotchas
+
+- **Renewal is automatic.** Traefik owns port 80 permanently and renews via HTTP-01 ~30 days
+  before expiry. No certbot cron needed (disable the old one — see migration above).
+- **Never delete `/opt/proxy/letsencrypt/acme.json`** once it holds a real cert — that forces
+  re-issuance and risks the production rate limit. Back it up instead.
+- **`--remove-orphans`** is what removes the legacy `LibreChat-NGINX` container when switching.
+  Never pass `-v` to `docker compose down` — it would delete the `pgdata2` named volume.
+- **Memory:** the droplet needs swap and ≥ 2 GB RAM. Meilisearch OOM-loops on a 1 GB box;
+  a 2 GB swapfile stabilizes it and leaves headroom for Traefik. Upgrade to ≥ 2 GB before
+  adding a second app (e.g. Strapi).
+- **`vectordb`** is on `librechat-network` here (it was on the default network in
+  `docker-compose.production.yml`, which isolated it from `rag_api`).

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,104 @@
+## LibreChat — production stack behind the centralized Traefik reverse proxy.
+##
+## This is the production deployment used on the Digital Ocean droplet. It is the
+## Traefik-aware successor to docker-compose.production.yml:
+##   - the nginx `client` sidecar is removed (Traefik terminates TLS on 80/443)
+##   - `api` is not published on the host; Traefik reaches it over the external `web` network
+##   - SSL is issued/renewed automatically by Traefik via Let's Encrypt (see utils/docker/proxy)
+##
+## Bring up with the shared project name so volumes/networks are reused:
+##   docker compose -p librechat -f docker-compose.traefik.yml up -d --remove-orphans
+##
+## MongoDB is NOT defined here on purpose — production uses MongoDB Atlas via MONGO_URI in .env.
+
+services:
+  api:
+    image: ghcr.io/lionelzoc/librechat:latest
+    platform: linux/amd64
+    container_name: LibreChat-API
+    restart: always
+    expose:
+      - "3080"                       # internal only; Traefik routes to it over the `web` network
+    env_file:
+      - .env
+    environment:
+      - HOST=0.0.0.0
+      - NODE_ENV=production
+      # MONGO_URI is provided by .env (MongoDB Atlas)
+      - MEILI_HOST=http://meilisearch:7700
+      - RAG_PORT=${RAG_PORT:-8000}
+      - RAG_API_URL=http://rag_api:${RAG_PORT:-8000}
+    volumes:
+      - ./librechat.yaml:/app/librechat.yaml
+      - ./images:/app/client/public/images
+      - ./uploads:/app/uploads
+      - ./logs:/app/api/logs
+    depends_on:
+      - rag_api
+    networks:
+      - librechat-network
+      - web
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.librechat.rule=Host(`chat.omniventus.com`)"
+      - "traefik.http.routers.librechat.entrypoints=websecure"
+      - "traefik.http.routers.librechat.tls.certresolver=le"
+      - "traefik.http.services.librechat.loadbalancer.server.port=3080"
+      - "traefik.docker.network=web"
+
+  # NOTE: the nginx `client` service is intentionally absent in Traefik mode.
+  #       It remains in docker-compose.production.yml for the nginx-based fallback.
+
+  meilisearch:
+    container_name: chat-meilisearch
+    image: getmeili/meilisearch:v1.5
+    platform: linux/amd64
+    restart: always
+    environment:
+      - MEILI_HOST=http://meilisearch:7700
+      - MEILI_NO_ANALYTICS=true
+      - MEILI_ENV=production
+      - MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
+    volumes:
+      - ./meili_data:/meili_data
+    networks:
+      - librechat-network
+
+  vectordb:
+    image: ankane/pgvector:latest
+    platform: linux/amd64
+    container_name: chat-vectordb
+    restart: always
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-mydatabase}
+      POSTGRES_USER: ${POSTGRES_USER:-myuser}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mypassword}
+    volumes:
+      - pgdata2:/var/lib/postgresql/data
+    networks:
+      - librechat-network        # was on the default network in production.yml — isolated from rag_api
+
+  rag_api:
+    image: ghcr.io/danny-avila/librechat-rag-api-dev-lite:latest
+    platform: linux/amd64
+    container_name: chat-rag-api
+    restart: always
+    environment:
+      - DB_HOST=vectordb
+      - RAG_PORT=${RAG_PORT:-8000}
+    depends_on:
+      - vectordb
+    env_file:
+      - .env
+    networks:
+      - librechat-network
+
+volumes:
+  pgdata2:
+  meili_data:
+
+networks:
+  librechat-network:
+    driver: bridge
+  web:
+    external: true

--- a/utils/docker/deploy-traefik.sh
+++ b/utils/docker/deploy-traefik.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+# Deploy LibreChat behind the centralized Traefik reverse proxy (Traefik mode).
+# Successor to utils/docker/deploy.sh, which deploys the legacy nginx-sidecar stack.
+#
+# Usage (from anywhere):  ./utils/docker/deploy-traefik.sh
+# Assumes the Traefik project lives at $PROXY_DIR (default /opt/proxy).
+
+cd "$(dirname "$0")/../.." || exit 1   # repo root
+
+PROXY_DIR="${PROXY_DIR:-/opt/proxy}"
+PROJECT="${COMPOSE_PROJECT:-librechat}"
+COMPOSE_FILE="docker-compose.traefik.yml"
+
+echo "==> Ensuring shared 'web' network exists..."
+docker network create web 2>/dev/null || true
+
+echo "==> Ensuring Traefik is running..."
+if ! docker ps --format '{{.Names}}' | grep -q '^traefik$'; then
+  if [ -f "$PROXY_DIR/docker-compose.yml" ]; then
+    echo "    Traefik not running — starting it from $PROXY_DIR"
+    (cd "$PROXY_DIR" && docker compose up -d)
+  else
+    echo "ERROR: Traefik is not running and $PROXY_DIR/docker-compose.yml is missing." >&2
+    echo "       Copy utils/docker/proxy/docker-compose.yml to $PROXY_DIR and read DEPLOYMENT-TRAEFIK.md." >&2
+    exit 1
+  fi
+fi
+
+[ -f .env ]          || { echo "ERROR: .env not found.";          exit 1; }
+[ -f librechat.yaml ] || { echo "ERROR: librechat.yaml not found."; exit 1; }
+
+echo "==> Pulling latest images..."
+docker compose -p "$PROJECT" -f "$COMPOSE_FILE" pull
+
+echo "==> Deploying LibreChat (Traefik mode)..."
+# --remove-orphans clears the legacy nginx `client` container if switching from the old stack.
+docker compose -p "$PROJECT" -f "$COMPOSE_FILE" up -d --remove-orphans
+
+echo "==> Done. Available at https://chat.omniventus.com"
+docker ps --format "table {{.Names}}\t{{.Status}}" | grep -E "traefik|LibreChat|chat-" || true

--- a/utils/docker/proxy/docker-compose.yml
+++ b/utils/docker/proxy/docker-compose.yml
@@ -1,0 +1,48 @@
+## Traefik — centralized reverse proxy for the droplet.
+##
+## This is an INDEPENDENT project. Deploy it under /opt/proxy on the server:
+##   sudo mkdir -p /opt/proxy/letsencrypt
+##   sudo cp utils/docker/proxy/docker-compose.yml /opt/proxy/docker-compose.yml
+##   sudo touch /opt/proxy/letsencrypt/acme.json && sudo chmod 600 /opt/proxy/letsencrypt/acme.json
+##   docker network create web        # shared network, created once
+##   cd /opt/proxy && docker compose up -d
+##
+## Traefik owns ports 80/443 for ALL projects on the droplet (LibreChat, Strapi, ...).
+## Each project opts in via Docker labels + membership of the external `web` network.
+##
+## FIRST-TIME SSL: uncomment the staging `caserver` line below, bring Traefik up, confirm a
+## staging cert issues (openssl ... -issuer shows "(STAGING)"), THEN comment it out, wipe
+## letsencrypt/acme.json, and bring it up again to obtain the real certificate. This avoids
+## burning the Let's Encrypt production rate limit while testing.
+
+services:
+  traefik:
+    image: traefik:v3.1
+    container_name: traefik
+    restart: always
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      # Global HTTP -> HTTPS redirect
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      # Let's Encrypt (HTTP-01 challenge on the `web` entrypoint)
+      - "--certificatesresolvers.le.acme.email=lionel@omniventus.com"
+      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.le.acme.httpchallenge.entrypoint=web"
+      # --- FIRST-TIME ONLY: uncomment to test against staging, then re-comment & re-issue ---
+      # - "--certificatesresolvers.le.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./letsencrypt:/letsencrypt        # acme.json lives here — DO NOT delete once it holds a real cert
+    networks:
+      - web
+
+networks:
+  web:
+    external: true


### PR DESCRIPTION
## Summary

Stacks on top of #7 (`feat/deploy`). Replaces the nginx-sidecar deployment with a
**centralized Traefik reverse proxy** so multiple projects can share ports 80/443 on
the same droplet without conflict (LibreChat now, Strapi/others next). This reflects the
configuration **now running in production** on the Digital Ocean droplet.

Traefik runs as its own project under `/opt/proxy`, owns 80/443, and issues + auto-renews
Let's Encrypt certs. LibreChat's `api` is no longer published on the host — Traefik routes
to it over a shared external `web` network via Docker labels.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Changes

- **`docker-compose.traefik.yml`** — LibreChat stack with the nginx `client` removed; `api`
  switched from a published `3080:3080` port to `expose` + Traefik routing labels on the
  `web` network. MongoDB stays on **Atlas** (`MONGO_URI` in `.env`).
- **`utils/docker/proxy/docker-compose.yml`** — standalone Traefik project (`/opt/proxy`):
  Let's Encrypt HTTP-01, global HTTP→HTTPS redirect.
- **`utils/docker/deploy-traefik.sh`** — deploy helper: ensures the `web` network + Traefik
  are up, then `docker compose -p librechat -f docker-compose.traefik.yml up -d --remove-orphans`.
- **`DEPLOYMENT-TRAEFIK.md`** — architecture, first-time SSL (staging→prod), cutover from
  nginx, rollback, and renewal notes.
- **fix:** `vectordb` now joins `librechat-network` (it was on the default network in
  `docker-compose.production.yml`, isolated from `rag_api`).

## Testing

Performed live on the production droplet:
- Cutover from the host nginx (which owned 80/443) to Traefik with ~1 min downtime.
- Validated SSL against Let's Encrypt **staging** first, then issued the real cert.
- `curl -sI https://chat.omniventus.com` → `HTTP/2 200` **without** `-k`; issuer is
  `Let's Encrypt` (no `(STAGING)`); HTTP→HTTPS 301 redirect confirmed.
- All services healthy after a 2 GB swapfile resolved the Meilisearch OOM loop.

## ⚠️ Risk

| Level | File |
|-------|------|
| High  | `docker-compose.traefik.yml` |
| High  | `utils/docker/proxy/docker-compose.yml` |
| Medium | `utils/docker/deploy-traefik.sh` |

No secrets committed — `.env` (MongoDB Atlas URI, `MEILI_MASTER_KEY`) stays on the server.
The legacy `docker-compose.production.yml` and host certs are kept intact as the rollback path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)